### PR TITLE
Array Chunk Pipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ You can find the documentations in the [`docs`](./docs) folder.
 * [`take`](./docs/array.md#take) 
 * [`drop`](./docs/array.md#drop) 
 * [`deep`](./docs/array.md#deep) 
+* [`chunk`](./docs/array.md#chunk) 
 
 
 ### Boolean

--- a/docs/array.md
+++ b/docs/array.md
@@ -21,6 +21,7 @@
 * [`take`](#take)
 * [`drop`](#drop)
 * [`deep`](#deep)
+* [`chunk`](#chunk)
 
 
 ####empty
@@ -501,4 +502,22 @@ collection: any[] = [
 ```html
 {{ collection | uniq }} <!-- The all collection (deep equal not working) -->
 {{ collection | deep | uniq }} <!-- [{ a: 1, b: { c: 3 } }] -->
+```
+
+
+####chunk
+
+The `chunk` pipe breaks the array into multiple, smaller arrays of a given size:
+
+##### File
+
+```
+import { ChunkPipe } from 'angular-pipes/pipes/src/array/chunk.pipe';
+```
+
+##### Usage
+
+```html
+{{ [1, 2, 3, 4] | chunk }} <!-- [[1],[2], [3], [4]] -->
+{{ [1, 2, 3, 4] | chunk: 2 }} <!-- [[1, 2], [3, 4]] -->
 ```

--- a/src/array.ts
+++ b/src/array.ts
@@ -19,6 +19,7 @@ import { ShufflePipe } from './array/shuffle.pipe';
 import { TakePipe } from './array/take.pipe';
 import { DropPipe } from './array/drop.pipe';
 import { DeepPipe } from './array/deep.pipe';
+import { ChunkPipe } from './array/chunk.pipe';
 
 export * from './array/empty.pipe';
 export * from './array/head.pipe';
@@ -41,6 +42,7 @@ export * from './array/shuffle.pipe';
 export * from './array/take.pipe';
 export * from './array/drop.pipe';
 export * from './array/deep.pipe';
+export * from './array/chunk.pipe';
 
 
 export const NG2_ARRAY_PIPES = [
@@ -64,5 +66,6 @@ export const NG2_ARRAY_PIPES = [
     ShufflePipe,
     TakePipe,
     DropPipe,
-    DeepPipe
+    DeepPipe,
+    ChunkPipe
 ];

--- a/src/array/chunk.pipe.ts
+++ b/src/array/chunk.pipe.ts
@@ -1,0 +1,22 @@
+import { Pipe, PipeTransform  } from '@angular/core';
+import { isArray } from '../utils/utils';
+
+@Pipe({
+  name: 'chunk'
+})
+export class ChunkPipe implements PipeTransform {
+
+  transform(input: any, size?: number): any {
+
+    if (!isArray(input)) {
+      return input;
+    }
+
+    let chunkSize = size || 1;
+
+    return [].concat.apply([], input.map((elem: any, i: number) => {
+        return i % chunkSize ? [] : [input.slice(i, i + chunkSize)];
+      })
+    );
+  }
+}

--- a/src/array/chunk.pipe.ts
+++ b/src/array/chunk.pipe.ts
@@ -6,16 +6,14 @@ import { isArray } from '../utils/utils';
 })
 export class ChunkPipe implements PipeTransform {
 
-  transform(input: any, size?: number): any {
+  transform(input: any, size = 1): any {
 
     if (!isArray(input)) {
       return input;
     }
 
-    let chunkSize = size || 1;
-
     return [].concat.apply([], input.map((elem: any, i: number) => {
-        return i % chunkSize ? [] : [input.slice(i, i + chunkSize)];
+        return i % size ? [] : [input.slice(i, i + size)];
       })
     );
   }

--- a/test/array/chunk.pipe.spec.ts
+++ b/test/array/chunk.pipe.spec.ts
@@ -1,0 +1,35 @@
+import { ChunkPipe } from '../../index';
+
+
+describe('ChunkPipe', () => {
+    
+    let pipe: ChunkPipe;
+    
+    beforeEach(() => {
+       pipe = new ChunkPipe(); 
+    });
+    
+    it('Should return []', () => {
+       
+       expect(pipe.transform([])).toEqual([]); 
+    });
+    
+    it('Should return [[1], [2], [3], [4]]', () => {
+       
+       const value = [1, 2, 3, 4];
+       
+       expect(pipe.transform(value)).toEqual([[1], [2], [3], [4]]); 
+       expect(value).toEqual([1, 2, 3, 4]); // Check integrity
+    });
+    
+    it ('Should return [[1, 2], [3, 4]]', () => {
+       
+       expect(pipe.transform([1, 2, 3, 4], 2)).toEqual([[1, 2], [3, 4]]); 
+    });
+    
+    it('Should return the value unchanged', () => {
+       
+       expect(pipe.transform('a')).toEqual('a'); 
+    });
+    
+})

--- a/test/main.spec.ts
+++ b/test/main.spec.ts
@@ -15,6 +15,7 @@ import './array/order-by.pipe.spec';
 import './array/shuffle.pipe.spec';
 import './array/take.pipe.spec';
 import './array/drop.pipe.spec';
+import './array/chunk.pipe.spec';
 
 
 import './boolean/conditions.pipe.spec';


### PR DESCRIPTION
The chunk pipe breaks the array into multiple, smaller arrays of a given size. Default size is 1.

Example:

{{ [1, 2, 3, 4] | chunk }} <!-- [[1],[2], [3], [4]] -->
{{ [1, 2, 3, 4] | chunk: 2 }} <!-- [[1, 2], [3, 4]] -->