### PR TITLE
Use --strictNullChecks and adapt type definitions

### DIFF
--- a/src/string/with.pipe.ts
+++ b/src/string/with.pipe.ts
@@ -4,7 +4,7 @@ import {isString, isNull} from '../utils/utils';
 @Pipe({name: 'with'})
 export class WithPipe implements PipeTransform {
   
-  transform(input: string, start: string = null, ends: string = null, csensitive: boolean = false): any {
+  transform(input: string, start: string | null = null, ends: string | null = null, csensitive: boolean = false): any {
     
     if (!isString(input) || (isNull(start) && isNull(ends)) || (start == '') || (ends == '')) {
       return input;

--- a/src/string/wrap.pipe.ts
+++ b/src/string/wrap.pipe.ts
@@ -11,4 +11,5 @@ export class WrapPipe implements PipeTransform {
   transform(input: string, wrap: string, ends?: string): string {
     return (isString(input) && !isUndefined(wrap)) ? [wrap, input, ends || wrap].join('') : input;
   }
+
 }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,43 +1,43 @@
 export type CollectionPredicate = (item?: any, index?: number, collection?: any[]) => boolean;
 
-export function isUndefined (value: any): boolean {
+export function isUndefined (value: any): value is undefined {
   
   return typeof value === 'undefined';
 }
 
-export function isNull (value: any): boolean {
+export function isNull (value: any): value is null {
   
   return value === null;
 }
 
-export function isNumber (value: any): boolean {
+export function isNumber (value: any): value is number {
   
   return typeof value === 'number';
 }
 
-export function isNumberFinite (value: any): boolean {
+export function isNumberFinite (value: any): value is number {
   
   return isNumber(value) && isFinite(value);
 }
 
 // Not strict positive
-export function isPositive (value: number): boolean {
+export function isPositive (value: number): value is number {
   
   return value >= 0;
 }
 
 
-export function isInteger (value: number): boolean {
+export function isInteger (value: number): value is number {
   
   // No rest, is an integer
   return (value % 1) === 0;
 }
 
-export function isNil (value: any): boolean {
+export function isNil (value: any): value is (null|undefined) {
   return value === null || typeof (value) === 'undefined';
 }
 
-export function isString (value: any): boolean {
+export function isString (value: any): value is string {
   
   return typeof value === 'string';
 }
@@ -179,7 +179,7 @@ export function getProperty (value: { [key: string]: any}, key: string): any {
   }
   
   const keys: string[] = key.split('.');
-  let result: any = value[keys.shift()];
+  let result: any = value[keys.shift()!];
   
   for (const key of keys) {
     if (isNil(result) || !isObject(result)) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,8 +8,9 @@
         "experimentalDecorators": true,
         "removeComments": false,
         "noImplicitAny": true,
-        "noUnusedLocals": true,        
+        "noUnusedLocals": true,
         "suppressImplicitAnyIndexErrors": false,
+        "strictNullChecks": true,
         "declaration": true,
         "types": [
             "core-js"


### PR DESCRIPTION
Resolves #45 

Note: the type guards on `isObject`, `isArray` and `isFunction` could probably need some more work with a generic type definition (using i.e. `function isObject (value: any): value is object` looses type information).
However I am currently not completely sure on how to write such a definition correctly so I rather kept it as is before breaking anything.