### PR TITLE
Allow no unused parameters

### DIFF
--- a/src/array/chunk.pipe.ts
+++ b/src/array/chunk.pipe.ts
@@ -12,7 +12,7 @@ export class ChunkPipe implements PipeTransform {
       return input;
     }
     
-    return [].concat.apply([], input.map((elem: any, i: number) => {
+    return [].concat.apply([], input.map((_elem: any, i: number) => {
       return i % size ? [] : [input.slice(i, i + size)];
     }));
   }

--- a/src/array/range.pipe.ts
+++ b/src/array/range.pipe.ts
@@ -5,7 +5,7 @@ import { Pipe, PipeTransform  } from '@angular/core';
 })
 export class RangePipe implements PipeTransform {
   
-  transform (input: any, size: number = 0, start: number = 1, step: number = 1): any {
+  transform (_input: any, size: number = 0, start: number = 1, step: number = 1): any {
     
     const range: number[] = [];
     for (let length = 0; length < size; ++length) {

--- a/src/array/without.pipe.ts
+++ b/src/array/without.pipe.ts
@@ -18,12 +18,12 @@ export class WithoutPipe implements PipeTransform {
         return unwrappedInput;
       }
       
-      return unwrappedInput.filter((value: any, index: number) => 
+      return unwrappedInput.filter((value: any) => 
       deepIndexOf(args, value) === -1
       );
     }
     
     
-    return input.filter((value: any, index: number) => args.indexOf(value) === -1);
+    return input.filter((value: any) => args.indexOf(value) === -1);
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
         "experimentalDecorators": true,
         "removeComments": false,
         "noImplicitAny": true,
-        "noUnusedLocals": true,        
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
         "suppressImplicitAnyIndexErrors": false,
         "declaration": true,
         "types": [


### PR DESCRIPTION
Currently when using angular-pipes in a project using the --noUnusedParameters flag errors are thrown.

This PR fixes it and avoids future errors by setting the option for this project.