### PR TITLE
Make angular-pipes work with strict null checks enabled

### DIFF
--- a/src/math/bytes.pipe.ts
+++ b/src/math/bytes.pipe.ts
@@ -31,9 +31,9 @@ export class BytesPipe implements PipeTransform {
 
     let bytes = input;
     let unit = from;
-    while (unit != 'B') {
+    while (unit !== 'B') {
       bytes *= 1024;
-      unit = BytesPipe.formats[unit].prev;
+      unit = BytesPipe.formats[unit].prev!;
     }
 
     for (const key in BytesPipe.formats) {

--- a/src/math/bytes.pipe.ts
+++ b/src/math/bytes.pipe.ts
@@ -40,7 +40,7 @@ export class BytesPipe implements PipeTransform {
       const format = BytesPipe.formats[key];
       if (bytes < format.max) {
 
-        const prev = BytesPipe.formats[format.prev];
+        const prev = format.prev ? BytesPipe.formats[format.prev] : undefined;
         
         const result = prev ?
           toDecimal(bytes / prev.max, decimal) : 


### PR DESCRIPTION
We are using this library in an Angular project, but there are a couple of errors thrown by the typescript compiler when strict null checks is enabled. This PR fixes that.