### PR TITLE
Allow empty strings on pipe parameters

### DIFF
--- a/src/string/replace.pipe.ts
+++ b/src/string/replace.pipe.ts
@@ -1,5 +1,5 @@
 import { Pipe, PipeTransform  } from '@angular/core';
-import { isString } from '../utils/utils';
+import { isString, isUndefined } from '../utils/utils';
 
 @Pipe({
   name: 'replace'
@@ -8,7 +8,7 @@ export class ReplacePipe implements PipeTransform {
   
   transform (input: any, pattern: any, replacement: any): any {
     
-    if (!isString(input) || !pattern || !replacement) {
+    if (!isString(input) || isUndefined(pattern) || isUndefined(replacement)) {
       return input;
     }
     


### PR DESCRIPTION
With previous implementation it was impossible to use this pipe to remove some patterns from the string.
This change is a fix to allow empty strings as replacement variables.

Previous behavior:
`{{ 'my string' | replace:' ':'' }}` returned `'my string'`

Fixed behavior:
`{{ 'my string' | replace:' ':'' }}` should return `'mystring'`
