### PR TITLE
Implement Ordinal Pipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ You can find the documentations in the [`docs`](./docs) folder or on [`GitBook`]
 * [`random`](./docs/math.md#random)
 * [`pow`](./docs/math.md#pow)
 * [`sqrt`](./docs/math.md#sqrt)
+* [`ordinal`](./docs/math.md#ordinal)
 
 ### Aggregate
 

--- a/docs/math.md
+++ b/docs/math.md
@@ -205,3 +205,21 @@ import { AbsPipe } from 'angular-pipes';
 ```html
 {{ -2 | abs }} <!-- 2 -->
 ```
+
+#### ordinal
+
+Returns the number with a suffix indicating the ordinal.
+
+##### File
+
+```typescript
+import { OrdinalPipe } from 'angular-pipes';
+```
+
+##### Usage
+
+```html
+{{ 1 | ordinal }} <!-- 1st -->
+{{ 523 | ordinal }} <!-- 523rd -->
+{{ 15 | ordinal }} <!-- 15th -->
+```

--- a/src/math/math.module.ts
+++ b/src/math/math.module.ts
@@ -10,6 +10,7 @@ import { RandomPipe } from './random.pipe';
 import { SqrtPipe } from './sqrt.pipe';
 import { PowPipe } from './pow.pipe';
 import { AbsPipe } from './abs.pipe';
+import { OrdinalPipe } from './ordinal.pipe';
 
 @NgModule({
   declarations: [
@@ -22,7 +23,8 @@ import { AbsPipe } from './abs.pipe';
     RandomPipe,
     SqrtPipe,
     PowPipe,
-	AbsPipe
+    AbsPipe,
+    OrdinalPipe
   ],
   exports: [
     BytesPipe,
@@ -34,7 +36,8 @@ import { AbsPipe } from './abs.pipe';
     RandomPipe,
     SqrtPipe,
     PowPipe,
-	AbsPipe
+    AbsPipe,
+    OrdinalPipe
   ]
 })
 export class NgMathPipesModule {}

--- a/src/math/ordinal.pipe.spec.ts
+++ b/src/math/ordinal.pipe.spec.ts
@@ -8,17 +8,22 @@ describe('OrdinalPipe', () => {
        pipe = new OrdinalPipe(); 
     });
     
-    it('Should return rd', () => {
+    it('Should return 123rd', () => {
         
         expect(pipe.transform(123)).toEqual('123rd');
     });
+
+    it('Should return 221st', () => {
+        
+        expect(pipe.transform(221)).toEqual('221st');
+    });
     
-    it('Should return nd', () => {
+    it('Should return 2nd', () => {
        
         expect(pipe.transform(2)).toEqual('2nd'); 
     });
 
-    it('Should return th', () => {
+    it('Should return 15th', () => {
        
         expect(pipe.transform(15)).toEqual('15th'); 
     });

--- a/src/math/ordinal.pipe.spec.ts
+++ b/src/math/ordinal.pipe.spec.ts
@@ -1,0 +1,30 @@
+import { OrdinalPipe } from './ordinal.pipe';
+
+describe('OrdinalPipe', () => {
+    
+    let pipe: OrdinalPipe;
+    
+    beforeEach(() => {
+       pipe = new OrdinalPipe(); 
+    });
+    
+    it('Should return rd', () => {
+        
+        expect(pipe.transform(123)).toEqual('123rd');
+    });
+    
+    it('Should return nd', () => {
+       
+        expect(pipe.transform(2)).toEqual('2nd'); 
+    });
+
+    it('Should return th', () => {
+       
+        expect(pipe.transform(15)).toEqual('15th'); 
+    });
+
+    it('Should return NaN', () => {
+        expect(pipe.transform('a')).toEqual('NaN');
+    });
+  
+});

--- a/src/math/ordinal.pipe.ts
+++ b/src/math/ordinal.pipe.ts
@@ -1,0 +1,25 @@
+import { Pipe, PipeTransform  } from '@angular/core';
+import { isNumberFinite } from '../utils/utils';
+
+@Pipe({
+  name: 'ordinal'
+})
+export class OrdinalPipe implements PipeTransform {
+  
+    transform (input: any): any {
+
+    if (!isNumberFinite(input)) {
+        return 'NaN';
+    }
+
+    var cardinal = input.toString().charAt(input.toString().length - 1);
+    if (cardinal == "1")
+        return input + "st";
+    else if (cardinal == "2")
+        return input + "nd";
+    else if (cardinal == "3")
+        return input + "rd";
+    else 
+        return input + "th";
+  }
+}

--- a/src/math/ordinal.pipe.ts
+++ b/src/math/ordinal.pipe.ts
@@ -8,18 +8,22 @@ export class OrdinalPipe implements PipeTransform {
   
     transform (input: any): any {
 
-    if (!isNumberFinite(input)) {
-        return 'NaN';
-    }
+        if (!isNumberFinite(input)) {
+            return 'NaN';
+        }
 
-    var cardinal = input.toString().charAt(input.toString().length - 1);
-    if (cardinal == "1")
-        return input + "st";
-    else if (cardinal == "2")
-        return input + "nd";
-    else if (cardinal == "3")
-        return input + "rd";
-    else 
-        return input + "th";
-  }
+        const cardinal = input.toString().charAt(input.toString().length - 1);
+
+        switch(cardinal) {
+            case '1':
+                return input + 'st';
+            case '2':
+                return input + 'nd';
+            case '3':
+                return input + 'rd';
+            default: 
+                return input + 'th';
+        }
+        
+    }
 }

--- a/src/public_api.ts
+++ b/src/public_api.ts
@@ -79,7 +79,7 @@ export { RandomPipe } from './math/random.pipe';
 export { SqrtPipe } from './math/sqrt.pipe';
 export { PowPipe } from './math/pow.pipe';
 export { AbsPipe } from './math/abs.pipe';
-
+export { OrdinalPipe } from './math/ordinal.pipe';
 export { KeysPipe } from './object/keys.pipe';
 export { ToArrayPipe } from './object/to-array.pipe';
 export { DefaultsPipe } from './object/defaults.pipe';


### PR DESCRIPTION
This pipe will add an ordinal suffix (eg. st, nd, rd) to a number, which is useful for displaying ranks in leaderboards and so on. 

**Examples:** 
```html
{{ 1 | ordinal }} <!-- 1st -->
{{ 22 | ordinal }} <!-- 22nd -->
{{ 523 | ordinal }} <!-- 523rd -->
{{ 15 | ordinal }} <!-- 15th -->
```