### PR TITLE
Update join.pipe.ts

### DIFF
--- a/src/array/join.pipe.ts
+++ b/src/array/join.pipe.ts
@@ -6,12 +6,12 @@ import { isArray } from '../utils/utils';
 })
 export class JoinPipe implements PipeTransform {
   
-  transform (input: any, character: string = ''): any {
+  transform (array: any, seperator: string): any {
     
-    if (!isArray(input)) {
-      return input;
+    if (!isArray(array)) {
+      return array;
     }
     
-    return input.join(character);
+    return input.join(seperator);
   }
 }


### PR DESCRIPTION
The parameter is called "seperator" not character. Also it should be undefined as default. Ref: https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Array/join